### PR TITLE
Update Alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
-FROM alpine:3.12 as build
+FROM alpine:3.23 AS build
 
 WORKDIR /app
 RUN apk add --no-cache \
   g++ \
-  make \ 
+  make \
   sqlite-dev
 
 COPY . .
 RUN make
 
-FROM alpine:3.12
+FROM alpine:3.23
 
 WORKDIR /app
-RUN apk add --no-cache \ 
-  sqlite-dev
+RUN apk add --no-cache \
+  sqlite-libs
 
 COPY --from=build /app/AdhocServer /app/AdhocServer
 COPY --from=build /app/database.db /app/database.db

--- a/src/main.c
+++ b/src/main.c
@@ -31,6 +31,7 @@
 #include <config.h>
 #include <user.h>
 #include <status.h>
+#include <unistd.h>
 
 // Server Status
 int _status = 0;

--- a/src/user.c
+++ b/src/user.c
@@ -25,6 +25,8 @@
 #include <status.h>
 #include <config.h>
 #include <sqlite3.h>
+#include <unistd.h>
+#include <sys/socket.h>
 
 // User Count
 uint32_t _db_user_count = 0;


### PR DESCRIPTION
Updates Alpine 3.12 (EOL) to Alpine 3.23.

The runtime image now installs sqlite-libs instead of sqlite-dev, since sqlite headers are only needed in the build stage.

Build tested locally and confirmed the resulting image uses Alpine 3.23.4.

Currently deployed live on a server and tested.